### PR TITLE
Updates to work better with PostgreSQL

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.simpledao</groupId>
     <artifactId>simpledao</artifactId>
-    <version>2.9</version>
+    <version>2.9.1</version>
     <name>SimpleDAO</name>
 
     <dependencies>

--- a/java/src/org/simpledao/AbstractDAO.java
+++ b/java/src/org/simpledao/AbstractDAO.java
@@ -32,9 +32,9 @@ public abstract class AbstractDAO<T>
                 con.close();
             }
         }
-        catch (SQLException ex)
+        catch ( SQLException ex)
         {
-            // no need to catch
+            log.error(ex.getMessage());
         }
     }
 
@@ -48,13 +48,11 @@ public abstract class AbstractDAO<T>
             con = getConnection();
             return dao.simpleSelectList(con, criteria);
         }
-/*
         catch ( SQLException ex)
         {
-            log.error(ex);
-            return null;
+            log.error(ex.getMessage());
+            throw ex;
         }
-*/
         finally
         {
             closeConnection(con);
@@ -71,13 +69,11 @@ public abstract class AbstractDAO<T>
             con = getConnection();
             return dao.simpleSelect(con, criteria);
         }
-/*
-        catch ( SQLException ex)
+        catch (SQLException ex)
         {
-            log.error(ex);
-            return null;
+            log.error(ex.getMessage());
+            throw ex;
         }
-*/
         finally
         {
             closeConnection(con);
@@ -94,12 +90,11 @@ public abstract class AbstractDAO<T>
             con = getConnection();
             dao.simpleInsert(con, criteria);
         }
-/*
         catch ( SQLException ex)
         {
-            log.error(ex);
+            log.error(ex.getMessage());
+            throw ex;
         }
-*/
         finally
         {
             closeConnection(con);
@@ -117,12 +112,11 @@ public abstract class AbstractDAO<T>
             con = getConnection();
             dao.simpleUpdate(con, criteria);
         }
-/*
         catch ( SQLException ex)
         {
-            log.error(ex);
+            log.error(ex.getMessage());
+            throw ex;
         }
-*/
         finally
         {
             closeConnection(con);
@@ -139,12 +133,11 @@ public abstract class AbstractDAO<T>
             con = getConnection();
             dao.simpleDelete(con, criteria);
         }
-/*
         catch ( SQLException ex)
         {
-            log.error(ex);
+            log.error(ex.getMessage());
+            throw ex;
         }
-*/
         finally
         {
             closeConnection(con);

--- a/java/src/org/simpledao/AbstractDAO.java
+++ b/java/src/org/simpledao/AbstractDAO.java
@@ -50,7 +50,7 @@ public abstract class AbstractDAO<T>
         }
         catch ( SQLException ex)
         {
-            log.error(ex.getMessage());
+            log.error(ex, ex.getMessage());
             throw ex;
         }
         finally
@@ -71,7 +71,7 @@ public abstract class AbstractDAO<T>
         }
         catch (SQLException ex)
         {
-            log.error(ex.getMessage());
+            log.error(ex, ex.getMessage());
             throw ex;
         }
         finally
@@ -92,7 +92,7 @@ public abstract class AbstractDAO<T>
         }
         catch ( SQLException ex)
         {
-            log.error(ex.getMessage());
+            log.error(ex, ex.getMessage());
             throw ex;
         }
         finally
@@ -114,7 +114,7 @@ public abstract class AbstractDAO<T>
         }
         catch ( SQLException ex)
         {
-            log.error(ex.getMessage());
+            log.error(ex, ex.getMessage());
             throw ex;
         }
         finally
@@ -135,7 +135,7 @@ public abstract class AbstractDAO<T>
         }
         catch ( SQLException ex)
         {
-            log.error(ex.getMessage());
+            log.error(ex, ex.getMessage());
             throw ex;
         }
         finally

--- a/java/src/org/simpledao/SimpleDAO.java
+++ b/java/src/org/simpledao/SimpleDAO.java
@@ -149,7 +149,7 @@ public class SimpleDAO<T>
             {
                 if ( columnPropertyMap.containsKey(metaData.getColumnName((i)).toUpperCase()))
                 {
-                    if ( metaData.getColumnType(i) == Types.BLOB )
+                    if ( metaData.getColumnType(i) == Types.BLOB || metaData.getColumnTypeName(i).equalsIgnoreCase("bytea") )
                     {
                         if ( log.isDebugEnabled() ) { log.debug("simpleSelectList - column # '" + i + "' is a BLOB");}
 
@@ -180,7 +180,7 @@ public class SimpleDAO<T>
                             props.put( Utils.getCamelCaseColumnName( metaData.getColumnName(i) ), baos.toByteArray() );
                         }
                     }
-                    else if  ( metaData.getColumnType(i) == Types.CLOB )
+                    else if  ( metaData.getColumnType(i) == Types.CLOB || metaData.getColumnTypeName(i).equalsIgnoreCase("text") )
                     {
                         if (log.isDebugEnabled())
                         {
@@ -189,17 +189,17 @@ public class SimpleDAO<T>
                         props.put(columnPropertyMap.get(metaData.getColumnName(i).toUpperCase()), rs.getString(i));
 
                     }
-                    else if ( metaData.getColumnType(i) == Types.DATE )
+                    else if ( metaData.getColumnType(i) == Types.DATE || metaData.getColumnTypeName(i).equalsIgnoreCase("date") )
                     {
                         if ( log.isDebugEnabled() ) { log.debug("simpleSelectList - column # '" + i + "' is a DATE");}
                         props.put( columnPropertyMap.get( metaData.getColumnName(i).toUpperCase()), rs.getTimestamp(i) );
                     }
-                    else if ( metaData.getColumnType(i) == Types.TIME )
+                    else if ( metaData.getColumnType(i) == Types.TIME || metaData.getColumnTypeName(i).equalsIgnoreCase("time") )
                     {
                         if ( log.isDebugEnabled() ) { log.debug("simpleSelectList - column # '" + i + "' is a TIME");}
                         props.put( columnPropertyMap.get( metaData.getColumnName(i).toUpperCase()), rs.getTime(i) );
                     }
-                    else if ( metaData.getColumnType(i) == Types.TIMESTAMP )
+                    else if ( metaData.getColumnType(i) == Types.TIMESTAMP || metaData.getColumnTypeName(i).equalsIgnoreCase("timestamp"))
                     {
                         if ( log.isDebugEnabled() ) { log.debug("simpleSelectList - column # '" + i + "' is a TIMESTAMP");}
                         props.put( columnPropertyMap.get( metaData.getColumnName(i).toUpperCase()), rs.getTimestamp(i) );
@@ -604,7 +604,7 @@ public class SimpleDAO<T>
     private PreparedStatement buildDeleteStatement( T bean, BeanDescriptor description,Connection con ) throws SQLException
     {
         ArrayList<BoundVariable> bindVariables = new ArrayList<BoundVariable>();
-        StringBuilder sql = new StringBuilder( "DELETE ");
+        StringBuilder sql = new StringBuilder( "DELETE FROM ");
 
         sql.append( description.getTable() );
         sql.append( " WHERE " );


### PR DESCRIPTION
Updating version to 2.9.1.  Adding catch statements inside AbstractDAO to aid in debugging errors.  Changing 'DELETE' to 'DELETE FROM' so it works in Oracle, SQL Server and PostgreSQL.  Adding check to column type detection to handle case where PostgreSQL cannot provide column type but can provide column type name.